### PR TITLE
version 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ Options:
       -sample:          the name of the plastome sample (default is the name in the fasta file)
 
 # Updates
-- Aug 28, 2015: I have recently discovered that the `/r` option for regular expressions was only introduced in Perl v5.14, so versions earlier than that will fail to compile Plann.pl properly. If this is the case, you will get this error:
+- Mar 25, 2016: 
+	Added line breaks in `analysis.sh` to help certain versions of bash.
+	Blast on Unix does not seem to like Windows line endings, which seems weird because the Genbank files downloaded from NCBI seem to come with them. Plann now rewrites temp versions of the genbank files with uniformly Unix line endings before running.
+	
+- Aug 28, 2015: 
+	I have recently discovered that the `/r` option for regular expressions was only introduced in Perl v5.14, so versions earlier than that will fail to compile Plann.pl properly. If this is the case, you will get this error:
 
 ```
 Bareword found where operator expected at plann-master/lib/Subfunctions.pm line 200, near "tr/[AGCT]//dr"

--- a/plann.pl
+++ b/plann.pl
@@ -49,7 +49,8 @@ if ($fastafile eq "") {
 }
 
 # a lot of genbank files seem to have windows line endings: we should convert to Unix endings before letting them go through Blast.
-my ($fh, $gbfile) = tempfile();
+my ($volume, $directories, $gbfilename) = File::Spec->splitpath($rawgbfile);
+my ($fh, $gbfile) = tempfile("$gbfilename.XXXX");
 open RAW_FH, "<:crlf", $rawgbfile;
 while (my $line=readline RAW_FH) {
 	print $fh $line;

--- a/test/analysis.sh
+++ b/test/analysis.sh
@@ -27,8 +27,10 @@ for GBF in *.gbf
 do
 	echo "Looking at proteins in $GBF:"
 	if grep -E '/translation="[^M]' $GBF
-		then echo "ERRORS! $GBF has errors in translation."
-		else echo "$GBF is fine."
+		then 
+			echo "ERRORS! $GBF has errors in translation."
+		else 
+			echo "$GBF is fine."
 	fi
 done;
 
@@ -38,8 +40,10 @@ do
 	grep -E '/translation=' $GB > $GB.orig
 	grep -E '/translation=' $GB.$GB.gbf > $GB.new
 	if diff $GB.orig $GB.new
-		then echo "$GB is fine"
-		else echo "$GB is not identical to $GB.$GB.gbf"
+		then 
+			echo "$GB is fine"
+		else 
+			echo "$GB is not identical to $GB.$GB.gbf"
 	fi
 done;
 


### PR DESCRIPTION
- Added line breaks in `analysis.sh` to help certain versions of bash.
- Blast on Unix does not seem to like Windows line endings, which seems weird because the Genbank files downloaded from NCBI seem to come with them. Plann now rewrites temp versions of the genbank files with uniformly Unix line endings before running.
